### PR TITLE
Add Win_Arm64 support and update version position URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         run: node version-position-crawler.js
       - name: 'Get position list'
         run: node position-crawler.js
-      - name: 'Generate Finial JSON'
+      - name: 'Generate Final JSON'
         run: node ver-pos-os-generator.js
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/constants.js
+++ b/constants.js
@@ -2,6 +2,7 @@ exports.OSList = [
   'Mac',
   'Mac_Arm',
   'Win_x64',
+  'Win_Arm64',
   'Win',
   'Linux_x64',
   'Linux',
@@ -14,7 +15,7 @@ exports.DownloadUrl =
 
 exports.VersionUrl = 'https://chromium.googlesource.com/chromium/src/+refs'
 
-exports.VersionPositionUrl = 'https://omahaproxy.appspot.com/deps.json?version='
+exports.VersionPositionUrl = 'https://chromiumdash.appspot.com/fetch_version?version='
 
 exports.PosReplaceExample = 'prefix=Mac'
 exports.PosReplaceStr = 'prefix='

--- a/version-position-crawler.js
+++ b/version-position-crawler.js
@@ -199,7 +199,10 @@ async function doIt(beginIdx) {
         done()
         return
       }
-      const pos = bodyObj.chromium_base_position
+      if (bodyObj.error && bodyObj.error.includes('No version data found')) {
+        bodyObj.chromium_main_branch_position = null
+      }
+      const pos = bodyObj.chromium_main_branch_position
       if (!pos) {
         // `null` pos will also be recorded
         // `null` pos is not changed after any times of request


### PR DESCRIPTION
- Added `Win_Arm64` to `OSList` in **constants.js**
- Updated `VersionPositionUrl` to use **chromiumdash** instead of **omahaproxy**.
- Fixed a typo in the CI workflow step name.